### PR TITLE
fix: update voyager links to voyager-on-testnet

### DIFF
--- a/public/lessons/starknet_contract.cairo
+++ b/public/lessons/starknet_contract.cairo
@@ -11,7 +11,7 @@
 #    For more information on how to write Cairo contracts see the
 #    ["Hello StarkNet" tutorial](https://cairo-lang.org/docs/hello_starknet).
 # 2. Click on the contract address in the output pane to open
-#    [Voyager](https://voyager.online/) - the StarkNet block explorer.
+#    [Voyager](https://goerli.voyager.online/) - the StarkNet block explorer.
 # 3. Wait for the page to load the information
 #    (it may take a few minutes until a block is created).
 # 4. In the "STATE" tab, you can call the "add()" transaction.

--- a/public/lessons/storage_vars.cairo
+++ b/public/lessons/storage_vars.cairo
@@ -24,7 +24,7 @@ end
 # given amount (note that we don't check that amount is positive).
 #
 # Complete the missing line and deploy the contract.
-# You can interact with it using [Voyager](https://voyager.online/).
+# You can interact with it using [Voyager](https://goerli.voyager.online/).
 @external
 func increase_balance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
         user_id : felt, amount : felt):

--- a/src/components/Features/Output/DeployOutput.js
+++ b/src/components/Features/Output/DeployOutput.js
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const CONTRACT_URL = 'https://voyager.online/contract/';
-const TX_URL = 'https://voyager.online/tx/';
+const CONTRACT_URL = 'https://goerli.voyager.online/contract/';
+const TX_URL = 'https://goerli.voyager.online/tx/';
 const DEPLOY_MSG_PARTS = [
   'The deployment transaction was sent.',
   'Contract address:',


### PR DESCRIPTION
### Description of the Changes

Replace 'https://voyager.online/' with 'https://goerli.voyager.online/' in all its 4 appearances in the code.