### PR TITLE
feat: add type annotations and format to cairo files

### DIFF
--- a/public/lessons/felt.cairo
+++ b/public/lessons/felt.cairo
@@ -23,7 +23,7 @@
 from starkware.cairo.common.serialize import serialize_word
 
 # Computes base^exp.
-func pow(base : felt, exp : felt) -> (res):
+func pow(base : felt, exp : felt) -> (res : felt):
     if exp == 0:
         return (res=1)
     end

--- a/public/lessons/hints.cairo
+++ b/public/lessons/hints.cairo
@@ -21,7 +21,7 @@ from starkware.cairo.common.serialize import serialize_word
 
 # Computes the square root (over the integers) of `n`.
 # Prover assumption: The square root exists.
-func sqrt(n) -> (res):
+func sqrt(n) -> (res : felt):
     alloc_locals
     local res
 

--- a/public/lessons/local_var_addr.cairo
+++ b/public/lessons/local_var_addr.cairo
@@ -16,7 +16,7 @@
 from starkware.cairo.common.registers import get_fp_and_pc
 
 # Returns a^3 for a != 0 and 1 otherwise.
-func foo(a) -> (res):
+func foo(a) -> (res : felt):
     if a == 0:
         return (res=1)
     else:

--- a/public/lessons/revoked.cairo
+++ b/public/lessons/revoked.cairo
@@ -28,7 +28,7 @@
 from starkware.cairo.common.serialize import serialize_word
 
 # Returns a^3 for a != 0 and 1 otherwise.
-func foo(a) -> (res):
+func foo(a) -> (res : felt):
     if a == 0:
         return (res=1)
     else:

--- a/public/lessons/storage_vars.cairo
+++ b/public/lessons/storage_vars.cairo
@@ -14,7 +14,8 @@ end
 
 @view
 func get_balance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        user_id : felt) -> (res : felt):
+    user_id : felt
+) -> (res : felt):
     # To read from the storage variable use balance.read().
     let (current_balance) = balance.read(user_id=user_id)
     return (res=current_balance)
@@ -27,7 +28,8 @@ end
 # You can interact with it using [Voyager](https://goerli.voyager.online/).
 @external
 func increase_balance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        user_id : felt, amount : felt):
+    user_id : felt, amount : felt
+):
     # Use balance.read to read the current balance into current_balance.
     # WRITE YOUR CODE HERE.
 

--- a/public/puzzles/amun.cairo
+++ b/public/puzzles/amun.cairo
@@ -261,7 +261,8 @@ func main{output_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
 
     let (local squashed_dict : DictAccess*) = alloc()
     let (squashed_dict_end) = squash_dict(
-        dict_accesses=state_start, dict_accesses_end=state, squashed_dict=squashed_dict)
+        dict_accesses=state_start, dict_accesses_end=state, squashed_dict=squashed_dict
+    )
     assert squashed_dict_end = squashed_dict + DictAccess.SIZE * 48
     local range_check_ptr = range_check_ptr
 

--- a/public/puzzles/anubis.cairo
+++ b/public/puzzles/anubis.cairo
@@ -20,7 +20,7 @@ struct Character:
     member resolve : felt
 end
 
-func merge_value{range_check_ptr}(a, b, seed) -> (seed, res):
+func merge_value{range_check_ptr}(a, b, seed) -> (seed : felt, res : felt):
     alloc_locals
     let (local seed, r) = unsigned_div_rem(seed, 3)
     let (res, _) = signed_div_rem(a + b + 2 * r - 2, 2, 2 * BOUND)
@@ -61,7 +61,8 @@ func merge{range_check_ptr}(a : Character*, b : Character*, seed) -> (merged : C
 end
 
 func add_new_characters{pedersen_ptr : HashBuiltin*, range_check_ptr}(
-        seed, characters : Character**, n_characters, n_new_characters):
+    seed, characters : Character**, n_characters, n_new_characters
+):
     if n_new_characters == 0:
         return ()
     end
@@ -86,7 +87,8 @@ func add_new_characters{pedersen_ptr : HashBuiltin*, range_check_ptr}(
         seed=seed,
         characters=characters,
         n_characters=n_characters + 1,
-        n_new_characters=n_new_characters - 1)
+        n_new_characters=n_new_characters - 1,
+    )
 end
 
 func main{output_ptr, pedersen_ptr : HashBuiltin*, range_check_ptr}():
@@ -106,7 +108,8 @@ func main{output_ptr, pedersen_ptr : HashBuiltin*, range_check_ptr}():
     local n_new_characters
     assert_nn_le(n_new_characters, 30)
     add_new_characters(
-        seed=0, characters=characters, n_characters=2, n_new_characters=n_new_characters)
+        seed=0, characters=characters, n_characters=2, n_new_characters=n_new_characters
+    )
 
     let last_character = [characters + 1 + n_new_characters]
     assert last_character.strength = 5

--- a/public/puzzles/khepri.cairo
+++ b/public/puzzles/khepri.cairo
@@ -20,7 +20,8 @@ func main{output_ptr : felt*, pedersen_ptr : HashBuiltin*, ecdsa_ptr : Signature
         x,
         124221662027375191599785306371100866827147974414679244246692561282978781776,
         signature_r,
-        signature_s)
+        signature_s,
+    )
 
     assert [output_ptr] = your_eth_addr
     let output_ptr = output_ptr + 1

--- a/public/puzzles/montu.cairo
+++ b/public/puzzles/montu.cairo
@@ -9,7 +9,8 @@ from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.cairo.common.hash_state import HashState, hash_finalize, hash_init, hash_update
 
 func compute_next_layer(
-        input : felt*, output : felt*, length : felt, alpha : felt, x : felt, g : felt):
+    input : felt*, output : felt*, length : felt, alpha : felt, x : felt, g : felt
+):
     tempvar a = [input]
     tempvar b = [input + length]
     assert [output] = (a + b) / 2 + alpha * (a - b) / (2 * x)
@@ -17,11 +18,13 @@ func compute_next_layer(
         return ()
     end
     return compute_next_layer(
-        input=input + 1, output=output + 1, length=length, alpha=alpha, x=x * g, g=g)
+        input=input + 1, output=output + 1, length=length, alpha=alpha, x=x * g, g=g
+    )
 end
 
 func verify{hash_ptr : HashBuiltin*, hash_state_ptr : HashState*}(
-        input : felt*, length : felt, g : felt):
+    input : felt*, length : felt, g : felt
+):
     alloc_locals
 
     if length == 2:
@@ -31,7 +34,8 @@ func verify{hash_ptr : HashBuiltin*, hash_state_ptr : HashState*}(
 
     # Compute alpha.
     let (hash_state_ptr) = hash_update(
-        hash_state_ptr=hash_state_ptr, data_ptr=input, data_length=length)
+        hash_state_ptr=hash_state_ptr, data_ptr=input, data_length=length
+    )
     let (alpha) = hash_finalize(hash_state_ptr=hash_state_ptr)
     local hash_ptr : HashBuiltin* = hash_ptr
     local hash_state_ptr : HashState* = hash_state_ptr
@@ -88,7 +92,8 @@ func main{output_ptr : felt*, pedersen_ptr : HashBuiltin*}():
     let (hash_state_ptr) = hash_init()
 
     verify{hash_ptr=pedersen_ptr, hash_state_ptr=hash_state_ptr}(
-        input=modified_input, length=LENGTH, g=G)
+        input=modified_input, length=LENGTH, g=G
+    )
 
     let output_ptr = output_ptr + 1
     return ()

--- a/public/puzzles/nu.cairo
+++ b/public/puzzles/nu.cairo
@@ -8,7 +8,7 @@
 
 from starkware.cairo.common.math import assert_nn
 
-func main(output_ptr : felt*, range_check_ptr) -> (output_ptr : felt*, range_check_ptr):
+func main(output_ptr : felt*, range_check_ptr) -> (output_ptr : felt*, range_check_ptr : felt):
     alloc_locals
     local x
     local y


### PR DESCRIPTION
This PR adds return types annotation and fixes the format using the return_type_migrator script.


