### PR TITLE
fix(3355924208): deploy transaction isn't working

### DIFF
--- a/src/api/playground.js
+++ b/src/api/playground.js
@@ -78,7 +78,7 @@ const compile = async code => {
   }
   return {
     contractAddress: response.address,
-    contractClass: response.contract_class
+    contractDefinition: response.contract_definition
   };
 };
 

--- a/src/api/starknet.js
+++ b/src/api/starknet.js
@@ -4,11 +4,11 @@ import {apiRequest} from './api-request';
 
 const path = process.env.REACT_APP_STARKNET_ALPHA_SERVICE_URL;
 
-const deploy = async contractClass => {
+const deploy = async contractDefinition => {
   let data = {
     type: ActionTypes.DEPLOY,
     contract_address_salt: `0x${generateRandomHex(248 / 4)}`,
-    contract_class: contractClass,
+    contract_definition: contractDefinition,
     constructor_calldata: []
   };
   const [response, error] = await apiRequest({

--- a/src/components/Features/Editor/Editor.js
+++ b/src/components/Features/Editor/Editor.js
@@ -295,10 +295,10 @@ const Editor = ({filePath}) => {
   };
 
   const doDeploy = async compileResponse => {
-    const {contractClass} = compileResponse;
+    const {contractDefinition} = compileResponse;
     program.addOutput(DEPLOYING_MSG);
     const [response, error] = await promiseHandler(
-      deploy(contractClass)
+      deploy(contractDefinition)
     );
     if (error) {
       DEPLOY_FAILED_MSG.push(error.message);


### PR DESCRIPTION
### Description of the Changes

- Rename back `contractClass` to `contractDefinition` and `contract_class` to `contract_definition` after talking with Yonatan Illuz who said that the request expects `definition` and not `class` when deploying (`${path}/gateway/add_transaction` ENDPOINT)


Solves #[3355924208](https://starkware.monday.com/boards/2847513897/pulses/3355924208)

---

### Checklist

- [x] Manually tests of the main Application flows are done and passed.
- [ ] New unit / functional tests have been added (whenever applicable).
- [ ] Docs have been updated (whenever relevant).
- [x] PR title is follow the [Conventional Commits](https://www.conventionalcommits.org/) convention: `<type>[optional scope]: <description>`, e.g: `fix: prevent racing of requests`
